### PR TITLE
fix: Update base minio image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Using specific tag for now, there was some reason newer minio versions didn't work
-FROM quay.io/cloudservices/minio:RELEASE.2021-06-17T00-10-46Z.hotfix.35a0912ff as minio-examples
+FROM quay.io/cloudservices/minio:RELEASE.2021-06-17T00-10-46Z as minio-examples
 
 EXPOSE 9000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Using specific tag to avoid newer minio versions that don't currently work
-FROM quay.io/minio/minio:RELEASE.2021-06-17T00-10-46Z as minio-examples
+FROM docker.io/minio/minio:RELEASE.2021-06-17T00-10-46Z.hotfix.35a0912ff as minio-examples
 
 EXPOSE 9000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Using specific tag to avoid newer minio versions that don't currently work
 FROM quay.io/minio/minio:RELEASE.2021-06-17T00-10-46Z as minio-examples
 
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/cloudservices/minio:RELEASE.2021-06-17T00-10-46Z as minio-examples
+FROM quay.io/minio/minio:RELEASE.2021-06-17T00-10-46Z as minio-examples
 
 EXPOSE 9000
 


### PR DESCRIPTION
The base image `quay.io/cloudservices/minio:RELEASE.2021-06-17T00-10-46Z.hotfix.35a0912ff` [stopped working](https://github.com/kserve/modelmesh-minio-examples/actions/runs/8789229245/job/24157853730#step:8:182). 