### PR TITLE
Updated base image to support Multi arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Using specific tag to avoid newer minio versions that don't currently work
-FROM docker.io/minio/minio:RELEASE.2021-06-17T00-10-46Z.hotfix.35a0912ff as minio-examples
+FROM docker.io/minio/minio:RELEASE.2024-03-30T09-41-56Z as minio-examples
 
 EXPOSE 9000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Using specific tag to avoid newer minio versions that don't currently work
-FROM quay.io/minio/minio:RELEASE.2023-10-16T04-13-43Z as minio-examples
+FROM docker.io/minio/minio:RELEASE.2021-06-17T00-10-46Z as minio-examples
 
 EXPOSE 9000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Using specific tag to avoid newer minio versions that don't currently work
-FROM docker.io/minio/minio:RELEASE.2024-03-30T09-41-56Z as minio-examples
+FROM quay.io/minio/minio:RELEASE.2023-10-16T04-13-43Z as minio-examples
 
 EXPOSE 9000
 


### PR DESCRIPTION
Base image in the dockerfile is compliant to amd64 only
Updated it with the multi-arch & tested that it is building multi-arch successfully
<img width="1540" alt="Screenshot 2024-05-01 at 16 26 28" src="https://github.com/kserve/modelmesh-minio-examples/assets/119933819/6369aa6f-5499-4b54-b540-c6cb59c3e249">

Fixes #12 